### PR TITLE
Maintain extra encoders and decoders while building subtype encoder/decoders

### DIFF
--- a/chili/decoder.py
+++ b/chili/decoder.py
@@ -441,7 +441,7 @@ def build_type_decoder(a_type: Type, extra_decoders: TypeDecoders = None, module
         raise DecoderError.invalid_type(a_type)
 
     type_attributes: List[Union[TypeDecoder, Any]] = [
-        build_type_decoder(subtype, module=module) if subtype is not ... else ...  # type: ignore
+        build_type_decoder(subtype, extra_decoders=extra_decoders, module=module) if subtype is not ... else ...  # type: ignore
         for subtype in get_type_args(a_type)
     ]
     if len(type_attributes) == 1:

--- a/chili/encoder.py
+++ b/chili/encoder.py
@@ -376,7 +376,7 @@ def build_type_encoder(a_type: Type, extra_encoders: TypeEncoders = None, module
         raise EncoderError.invalid_type(a_type)
 
     type_attributes: List[TypeEncoder] = [
-        build_type_encoder(subtype, module=module) if subtype is not ... else ...  # type: ignore
+        build_type_encoder(subtype, extra_encoders=extra_encoders, module=module) if subtype is not ... else ...  # type: ignore
         for subtype in get_type_args(a_type)
     ]
 


### PR DESCRIPTION
Just two small changes. That solves the issue in my end. 

What do you think?