### PR TITLE
Add support for dataclasses with InitVar

### DIFF
--- a/chili/typing.py
+++ b/chili/typing.py
@@ -201,6 +201,13 @@ def create_schema(cls: Type) -> TypeSchema:
         # ignore class vars as they are not object properties
         if p_origin and p_origin is ClassVar:
             continue
+        
+        # ignore init-only variables as they go out of scope when object is encoded (serialized)
+        if type(p_type) is InitVar:
+            if not name in attributes:
+                # not optional init-only variables make decoding (deserialization) impossible as they do not persist in encoding (serialization)
+                warnings.warn(f"Dataclass field '{name}' is InitVar without default value. Decoding is impossible!")
+            continue
 
         if name in attributes:
             prop_value = attributes[name]

--- a/chili/typing.py
+++ b/chili/typing.py
@@ -6,7 +6,7 @@ import warnings
 from dataclasses import Field, is_dataclass, MISSING
 from enum import Enum
 from inspect import isclass as is_class
-from typing import Any, Dict, List, Optional, Type, Union, ClassVar, NewType, Callable
+from typing import Any, Dict, List, Optional, Type, Union, ClassVar, NewType, Callable, InitVar
 
 from chili.error import SerialisationError
 

--- a/chili/typing.py
+++ b/chili/typing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import typing
+import warnings
 from dataclasses import Field, is_dataclass, MISSING
 from enum import Enum
 from inspect import isclass as is_class


### PR DESCRIPTION
- Ignore init-only variables as they go out of scope when object is
encoded (serialized)
- Warn on encoding (serialization) of dataclass with InitVar without
default value: decoding (deserialization) is impossible!