### PR TITLE
Do not allow incomplete objects to be created

### DIFF
--- a/chili/decoder.py
+++ b/chili/decoder.py
@@ -539,7 +539,10 @@ class Decoder(Generic[T]):
 
         for key, prop in self.schema.items():
             if key not in obj:
-                value = prop.default_value
+                if is_optional(prop.type):
+                    value = prop.default_value
+                else:
+                    raise DecoderError.missing_property(key=key)
             else:
                 value = self._decoders[prop.name].decode(obj[key])
 

--- a/chili/encoder.py
+++ b/chili/encoder.py
@@ -441,8 +441,11 @@ class Encoder(Generic[T]):
 
         result = {}
         for key, prop in self.schema.items():
-            value = getattr(obj, key, prop.default_value)
-            if value is UNDEFINED:
+            if hasattr(obj, key):
+                value = getattr(obj, key)
+            elif is_optional(prop.type):
+                value = prop.default_value
+            else:
                 continue
             result[key] = self._encoders[prop.name].encode(value)
 

--- a/chili/error.py
+++ b/chili/error.py
@@ -6,6 +6,7 @@ class SerialisationError(Error):
     strict_type_violation: ValueError
     invalid_type: TypeError
     invalid_input: ValueError
+    missing_property: KeyError
 
 
 class DecoderError(SerialisationError):

--- a/chili/typing.py
+++ b/chili/typing.py
@@ -167,7 +167,7 @@ class Property:
         if self._default_factory:
             return self._default_factory()
 
-        return UNDEFINED
+        return None
 
     def __eq__(self, other: Property) -> bool:  # type: ignore
         return self.name == other.name and self.type is other.type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ license = "MIT"
 name = "chili"
 readme = "README.md"
 repository = "https://github.com/kodemore/chili"
-version = "2.3.1"
+version = "2.4.0"
 
 [tool.poetry.dependencies]
 gaffe = "0.2.0"

--- a/tests/usecases/dataclasses_test.py
+++ b/tests/usecases/dataclasses_test.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Generic, List, TypeVar
+from typing import Generic, List, Optional, TypeVar
 
 import pytest
 
@@ -123,7 +123,7 @@ def test_can_decode_with_default_values() -> None:
     class Book:
         name: str
         author: str
-        tags: List[str] = field(default_factory=list)
+        tags: Optional[List[str]] = field(default_factory=list)
 
     book_data = {"name": "The Hobbit", "author": "J.R.R. Tolkien"}
     decoder = Decoder[Book]()

--- a/tests/usecases/decodable_test.py
+++ b/tests/usecases/decodable_test.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from chili import Decoder, Mapper, decodable
 
@@ -9,8 +9,8 @@ def test_decodable_with_default_values() -> None:
     class Book:
         name: str
         author: str
-        isbn: str = "1234567890"
-        tags: List[str] = []
+        isbn: Optional[str] = "1234567890"
+        tags: Optional[List[str]] = []
 
     book_data = {"name": "The Hobbit", "author": "J.R.R. Tolkien"}
     decoder = Decoder[Book]()


### PR DESCRIPTION
This PR changes current behaviour and disallows decoding incomplete objects unless missing properties are marked as optional with `typing.Optional` annotation.