### PR TITLE
First approach for the issue #25

### DIFF
--- a/chili/decoder.py
+++ b/chili/decoder.py
@@ -120,18 +120,17 @@ def decode_regex_from_string(value: str) -> Pattern:
 def decodable(_cls=None, mapper: Optional[Mapper] = None) -> Any:
     def _decorate(cls) -> Type[C]:
         # Attach schema to make the class decodable
-        if not hasattr(cls, _PROPERTIES):
-            setattr(cls, _PROPERTIES, create_schema(cls))
-            if mapper:
-                setattr(cls, _DECODE_MAPPER, mapper)
+        setattr(cls, _PROPERTIES, create_schema(cls))
+        if mapper:
+            setattr(cls, _DECODE_MAPPER, mapper)
 
-            inner_classes = [
-                icls
-                for icls in cls.__dict__.values()
-                if isclass(icls) and icls.__module__ == cls.__module__ and not hasattr(icls, _PROPERTIES)
-            ]
-            for inner_class in inner_classes:
-                _decorate(inner_class)
+        inner_classes = [
+            icls
+            for icls in cls.__dict__.values()
+            if isclass(icls) and icls.__module__ == cls.__module__ and not hasattr(icls, _PROPERTIES)
+        ]
+        for inner_class in inner_classes:
+            _decorate(inner_class)
 
         setattr(cls, _DECODABLE, True)
 

--- a/chili/encoder.py
+++ b/chili/encoder.py
@@ -88,18 +88,17 @@ def encode_regex_to_string(value: Pattern) -> str:
 def encodable(_cls=None, mapper: Optional[Mapper] = None) -> Any:
     def _decorate(cls) -> Type[C]:
         # Attach schema to make the class encodable
-        if not hasattr(cls, _PROPERTIES):
-            setattr(cls, _PROPERTIES, create_schema(cls))
-            if mapper:
-                setattr(cls, _ENCODE_MAPPER, mapper)
+        setattr(cls, _PROPERTIES, create_schema(cls))
+        if mapper:
+            setattr(cls, _ENCODE_MAPPER, mapper)
 
-            inner_classes = [
-                icls
-                for icls in cls.__dict__.values()
-                if isclass(icls) and icls.__module__ == cls.__module__ and not hasattr(icls, _PROPERTIES)
-            ]
-            for inner_class in inner_classes:
-                _decorate(inner_class)
+        inner_classes = [
+            icls
+            for icls in cls.__dict__.values()
+            if isclass(icls) and icls.__module__ == cls.__module__ and not hasattr(icls, _PROPERTIES)
+        ]
+        for inner_class in inner_classes:
+            _decorate(inner_class)
 
         setattr(cls, _ENCODABLE, True)
 

--- a/chili/serializer.py
+++ b/chili/serializer.py
@@ -49,13 +49,12 @@ class Serializer(Encoder, Decoder, Generic[T]):
 
 
 def serializable(_cls=None, in_mapper: Optional[Mapper] = None, out_mapper: Optional[Mapper] = None) -> Any:
-    def _decorate(cls) -> Type[C]:
-        if not hasattr(cls, _PROPERTIES):
-            setattr(cls, _PROPERTIES, create_schema(cls))
-            if in_mapper is not None:
-                setattr(cls, _DECODE_MAPPER, in_mapper)
-            if out_mapper is not None:
-                setattr(cls, _ENCODE_MAPPER, out_mapper)
+    def _decorate(cls) -> Type[C]:        
+        setattr(cls, _PROPERTIES, create_schema(cls))
+        if in_mapper is not None:
+            setattr(cls, _DECODE_MAPPER, in_mapper)
+        if out_mapper is not None:
+            setattr(cls, _ENCODE_MAPPER, out_mapper)
 
         setattr(cls, _DECODABLE, True)
         setattr(cls, _ENCODABLE, True)


### PR DESCRIPTION
As mentioned in the issue #25, this is one solution to the problem. However, this change directly overrides the schema every single time. I guess that the original devs added the check `if not hasattr(cls, _PROPERTIES):` for a reason.

So, in conclusion, if you still want to maintain that check for efficiency, or for other reasons of the code I still don't know. I have a second solution prepared.